### PR TITLE
feat: Add remote button click relay (+ error toast notifications)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -124,6 +124,42 @@
         .chat-content button {
             cursor: pointer;
         }
+
+        /* Toast notifications */
+        .toast {
+            position: fixed;
+            bottom: 80px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: #ef4444;
+            color: white;
+            padding: 12px 40px 12px 16px;
+            border-radius: 8px;
+            font-size: 14px;
+            z-index: 9999;
+            animation: fadeIn 0.2s;
+            max-width: 90%;
+        }
+
+        .toast .close {
+            position: absolute;
+            right: 8px;
+            top: 50%;
+            transform: translateY(-50%);
+            background: none;
+            border: none;
+            color: white;
+            font-size: 18px;
+            cursor: pointer;
+            padding: 4px 8px;
+        }
+
+        @keyframes fadeIn {
+            from {
+                opacity: 0;
+                transform: translateX(-50%) translateY(10px);
+            }
+        }
     </style>
     <style id="cascade-style">
         /* Dynamic styles will be injected here */
@@ -156,6 +192,18 @@
         let cascades = [];
         let currentCascadeId = null;
         let ws = null;
+
+        function showToast(msg, duration = 4000) {
+            const existing = document.querySelector('.toast');
+            if (existing) existing.remove();
+
+            const toast = document.createElement('div');
+            toast.className = 'toast';
+            toast.innerHTML = msg + '<button class="close" onclick="this.parentElement.remove()">×</button>';
+            document.body.appendChild(toast);
+
+            setTimeout(() => toast.remove(), duration);
+        }
 
         function connect() {
             ws = new WebSocket(`ws://${location.host}`);
@@ -315,12 +363,14 @@
                 if (!res.ok) {
                     const err = await res.json();
                     console.error('Click failed:', err);
+                    showToast(err.error || err.reason || 'Click failed');
                 }
 
                 // Refresh after click
                 setTimeout(() => updateContentOnly(currentCascadeId), 300);
             } catch (err) {
                 console.error('Click relay error:', err);
+                showToast('Network error: ' + err.message);
             }
         });
 

--- a/public/index.html
+++ b/public/index.html
@@ -119,6 +119,11 @@
             color: #666;
             margin-top: 50px;
         }
+
+        /* Make buttons in chat content clickable */
+        .chat-content button {
+            cursor: pointer;
+        }
     </style>
     <style id="cascade-style">
         /* Dynamic styles will be injected here */
@@ -284,6 +289,38 @@
             if (e.key === 'Enter' && !e.shiftKey) {
                 e.preventDefault();
                 sendMessage();
+            }
+        });
+
+        // Relay button clicks back to Antigravity
+        chatContent.addEventListener('click', async (e) => {
+            const btn = e.target.closest('button');
+            if (!btn || !currentCascadeId) return;
+
+            const relayId = btn.getAttribute('data-relay-id');
+            if (!relayId) return; // Not a relayable button
+
+            e.preventDefault();
+            e.stopPropagation();
+
+            console.log('Relaying click:', relayId);
+
+            try {
+                const res = await fetch(`/click/${currentCascadeId}`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ relayId })
+                });
+
+                if (!res.ok) {
+                    const err = await res.json();
+                    console.error('Click failed:', err);
+                }
+
+                // Refresh after click
+                setTimeout(() => updateContentOnly(currentCascadeId), 300);
+            } catch (err) {
+                console.error('Click relay error:', err);
             }
         });
 


### PR DESCRIPTION
## Add remote button click relay for command approval
Finally, you can approve commands from your phone while your legs go numb on the throne. No more awkward waddle back to the desk just to click "Accept" — your porcelain productivity sessions can now remain uninterrupted. 🚽✨

### What changed

**Frontend (public/index.html)**
- Added click handler that intercepts button clicks in the chat view
- Sends button's relay ID back to the server
- Added toast notifications for error feedback (non-blocking, auto-dismiss after 4s)

**Backend (server.js)**
- Buttons get tagged with `data-relay-id` in the HTML snapshot (clone only — doesn't touch the live Antigravity DOM)
- New `/click/:id` endpoint to relay clicks back to Antigravity via CDP
- Each button is identified by its DOM path + text content
- Before clicking, verifies the button text still matches to prevent mis-clicks if the chat has updated

### Safety
Clicks are only executed when both:
1. The DOM path leads to a `<button>` element
2. The button's text matches what was captured in the snapshot
If the DOM changed between snapshot and click, it fails gracefully with a toast notification instead of clicking the wrong thing.
### Commits
- `feat: add remote button click relay for command approval`
- `feat: add toast notifications for click errors`
